### PR TITLE
Change name "Server" in "server" in CmakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(BUILD_CLIENT)
 endif()
 
 if(BUILD_SERVER)
-  add_subdirectory(Server)
+  add_subdirectory(server)
 endif()
 
 if(BUILD_TESTS)


### PR DESCRIPTION
This pull request makes a minor update to the `CMakeLists.txt` file, correcting the case of the `Server` directory to `server` in the `add_subdirectory` command. This ensures consistency with the actual directory naming and avoids potential build issues on case-sensitive file systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Correctifs
  * Correction du chemin de construction du module serveur pour les systèmes de fichiers sensibles à la casse, évitant des erreurs de compilation lorsque l’option de build du serveur est activée.
  * Garantit que le bon répertoire du serveur est pris en compte pendant la compilation, améliorant la fiabilité du processus de build sur différentes plateformes.
* Tâches
  * Harmonisation de la configuration de build pour une meilleure compatibilité multi-OS et une maintenance simplifiée du pipeline de compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->