### PR TITLE
Server/remove compilation for files that use raylib.h

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -4,15 +4,28 @@ find_package(Threads REQUIRED)
 set(PROJECT_NAME r_type_server)
 
 file(GLOB_RECURSE SERVER_SOURCES CONFIGURE_DEPENDS "src/*.cpp")
-file(GLOB_RECURSE GAME_ENGINE_SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/game_engine/ecs/*.cpp")
-list(REMOVE_ITEM GAME_ENGINE_SOURCES "${CMAKE_SOURCE_DIR}/game_engine/ecs/systems/InputSystem.cpp")
+file(GLOB_RECURSE ALL_GAME_ENGINE_SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/game_engine/ecs/*.cpp")
+
+set(GAME_ENGINE_SOURCES "")
+foreach(source_file ${ALL_GAME_ENGINE_SOURCES})
+    execute_process(
+        COMMAND grep -l "raylib\.h" ${source_file}
+        RESULT_VARIABLE result
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    
+    if(NOT result EQUAL 0)
+        list(APPEND GAME_ENGINE_SOURCES ${source_file})
+    endif()
+endforeach()
 
 add_executable(${PROJECT_NAME}
   ${SERVER_SOURCES}
   ${GAME_ENGINE_SOURCES}
 )
-add_compile_options(-W -Wall -Wextra)
 
+add_compile_options(-W -Wall -Wextra)
 target_link_libraries(${PROJECT_NAME} asio::asio Threads::Threads)
 target_include_directories(${PROJECT_NAME} PRIVATE
   src/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactorisation
  - Ajustement du système de build pour collecter dynamiquement les sources et exclure automatiquement certains fichiers selon leurs dépendances, réduisant la maintenance manuelle et les erreurs.
- Tâches
  - Harmonisation des options de compilation et des répertoires d’inclusion tout en conservant les liens avec les bibliothèques existantes.
  - Amélioration mineure de la stabilité du build; une option de compilation en double est conservée sans impact fonctionnel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->