### PR TITLE
CICD/new ci-cd to build the windows version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -47,11 +47,9 @@ jobs:
           export PATH="/mingw64/bin:$PATH"
           export CC=gcc
           export CXX=g++
-          export CONAN_USER_HOME=$HOME
-
+          export CMAKE_MAKE_PROGRAM=ninja
           conan profile detect --force
           conan profile show
-          conan config set tools.cmake.cmaketoolchain:generator=Ninja
 
       - name: Build Release
         shell: msys2 {0}
@@ -60,6 +58,7 @@ jobs:
           export CC=gcc
           export CXX=g++
           export CMAKE_MAKE_PROGRAM=ninja
+          export CONAN_CMAKE_GENERATOR=Ninja
           chmod +x build.sh
           ./build.sh
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Nouveautés
  - Publication automatique de builds Windows avec exécutables téléchargeables (client et serveur).
  - Génération d’un tag de version daté pour chaque publication sur la branche principale.

- Documentation
  - Inclusion d’instructions de téléchargement, d’installation et d’utilisation dans chaque Release.

- Chores
  - Mise en place du pipeline de build et publication continue, avec vérification stricte de la présence des artefacts avant publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->