### PR TITLE
Ci cd/windows release (#116)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -105,7 +105,7 @@ jobs:
         run: echo "tag=v$(date +'%Y.%m.%d')-$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: R-Type Release ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
* feat: new ci-cd to build the windows version

* fix: version of artifacts

* fix: python to python3

* fix: add python to dependencies for mingw

* fix: try to detect gcc

* fix: profile show from conan1 to conan2

* fix: force ninja

* rem: conan1 set

* fix: change for action gh

* fix: 2 artifacts

* fix: try to use gh v2