### PR TITLE
refactor(macros): rename SUCCESS/ERROR to OK/KO

### DIFF
--- a/server/src/Macros.hpp
+++ b/server/src/Macros.hpp
@@ -1,12 +1,8 @@
 #pragma once
 
-#ifdef ERROR
-  #undef ERROR
-#endif
-
 /* Macros for function's returns */
-constexpr int SUCCESS = 0;
-constexpr int ERROR = -1;
+constexpr int OK = 0;
+constexpr int KO = -1;
 
 /* Macros for ports */
 constexpr int MAX_PORT = 65535;

--- a/server/src/Server.cpp
+++ b/server/src/Server.cpp
@@ -233,7 +233,7 @@ void server::Server::handleReceive(const asio::error_code &error,
   }
 
   int client_idx = findOrCreateClient(_remote_endpoint);
-  if (client_idx == ERROR) {
+  if (client_idx == KO) {
     std::cerr << "[WARNING] Max clients reached. Refused connection."
               << std::endl;
     startReceive();
@@ -270,7 +270,7 @@ int server::Server::findOrCreateClient(
     }
   }
 
-  return ERROR;
+  return KO;
 }
 
 /*

--- a/server/src/enemy/Enemy.cpp
+++ b/server/src/enemy/Enemy.cpp
@@ -35,7 +35,7 @@ int game::Enemy::getHealth() const {
     const auto &health = getComponent<ecs::HealthComponent>();
     return health.health;
   }
-  return SUCCESS;
+  return OK;
 }
 
 int game::Enemy::getMaxHealth() const {
@@ -43,7 +43,7 @@ int game::Enemy::getMaxHealth() const {
     const auto &health = getComponent<ecs::HealthComponent>();
     return health.max_health;
   }
-  return SUCCESS;
+  return OK;
 }
 
 void game::Enemy::setHealth(int health) {

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -12,7 +12,7 @@ int main(int ac, char **av) {
   try {
     if (ac == 2 && std::strcmp(av[1], "--help") == 0) {
       Help::help();
-      return SUCCESS;
+      return OK;
     } else if (ac >= 2) {
       throw ParamsError(
           "Too much arguments, check --help for more informations.");
@@ -40,10 +40,10 @@ int main(int ac, char **av) {
     io_context.run();
   } catch (const ParamsError &e) {
     std::cerr << "Error: " << e.what() << std::endl;
-    return ERROR;
+    return KO;
   } catch (const std::exception &e) {
     std::cerr << "Error: " << e.what() << std::endl;
-    return ERROR;
+    return KO;
   }
-  return SUCCESS;
+  return OK;
 }

--- a/server/src/packets/PacketHandler.cpp
+++ b/server/src/packets/PacketHandler.cpp
@@ -12,13 +12,13 @@ int packet::MessageHandler::handlePacket([[maybe_unused]] server::Server &,
                                          server::Client &client,
                                          const char *data, std::size_t size) {
   if (size < sizeof(MessagePacket)) {
-    return ERROR;
+    return KO;
   }
 
   const MessagePacket *packet = reinterpret_cast<const MessagePacket *>(data);
   std::cout << "[MESSAGE] Player " << client._player_id << ": "
             << packet->message << std::endl;
-  return SUCCESS;
+  return OK;
 }
 
 int packet::PlayerInfoHandler::handlePacket(server::Server &server,
@@ -26,7 +26,7 @@ int packet::PlayerInfoHandler::handlePacket(server::Server &server,
                                             const char *data,
                                             std::size_t size) {
   if (size < sizeof(PlayerInfoPacket)) {
-    return ERROR;
+    return KO;
   }
 
   const PlayerInfoPacket *packet =
@@ -60,20 +60,20 @@ int packet::PlayerInfoHandler::handlePacket(server::Server &server,
   broadcast::Broadcast::broadcastAncientPlayer(
       server.getSocket(), server.getClients(), newPlayerPacket);
 
-  return SUCCESS;
+  return OK;
 }
 
 int packet::PositionHandler::handlePacket(server::Server &server,
                                           server::Client &client,
                                           const char *data, std::size_t size) {
   if (size < sizeof(PositionPacket)) {
-    return ERROR;
+    return KO;
   }
   const PositionPacket *packet = reinterpret_cast<const PositionPacket *>(data);
 
   auto player = server.getGame().getPlayer(client._player_id);
   if (!player) {
-    return ERROR;
+    return KO;
   }
 
   float oldX = player->getPosition().first;
@@ -96,7 +96,7 @@ int packet::PositionHandler::handlePacket(server::Server &server,
       std::cout << "[ANTICHEAT] Player " << client._player_id
                 << " is moving too fast!" << std::endl;
       player->setSequenceNumber(packet->sequence_number);
-      return ERROR;
+      return KO;
     }
   }
   player->setPosition(packet->x, packet->y);
@@ -108,21 +108,21 @@ int packet::PositionHandler::handlePacket(server::Server &server,
       client._player_id, player->getSequenceNumber(), pos.first, pos.second);
   broadcast::Broadcast::broadcastPlayerMove(server.getSocket(),
                                             server.getClients(), movePacket);
-  return SUCCESS;
+  return OK;
 }
 
 int packet::HeartbeatPlayerHandler::handlePacket(
     [[maybe_unused]] server::Server &server, server::Client &client,
     const char *data, std::size_t size) {
   if (size < sizeof(HeartbeatPlayerPacket)) {
-    return ERROR;
+    return KO;
   }
   const auto *hb = reinterpret_cast<const HeartbeatPlayerPacket *>(data);
   if (hb->player_id != static_cast<uint32_t>(client._player_id)) {
-    return ERROR;
+    return KO;
   }
   client._last_heartbeat = std::chrono::steady_clock::now();
-  return SUCCESS;
+  return OK;
 }
 
 int packet::PlayerShootHandler::handlePacket(server::Server &server,
@@ -130,7 +130,7 @@ int packet::PlayerShootHandler::handlePacket(server::Server &server,
                                              const char *data,
                                              std::size_t size) {
   if (size < sizeof(PlayerShootPacket)) {
-    return ERROR;
+    return KO;
   }
 
   const PlayerShootPacket *packet =
@@ -138,7 +138,7 @@ int packet::PlayerShootHandler::handlePacket(server::Server &server,
 
   auto player = server.getGame().getPlayer(client._player_id);
   if (!player) {
-    return ERROR;
+    return KO;
   }
 
   std::pair<float, float> pos = player->getPosition();
@@ -160,7 +160,7 @@ int packet::PlayerShootHandler::handlePacket(server::Server &server,
       vx, vy);
 
   if (!projectile) {
-    return ERROR;
+    return KO;
   }
 
   auto playerShotPacket = PacketBuilder::makePlayerShoot(
@@ -168,7 +168,7 @@ int packet::PlayerShootHandler::handlePacket(server::Server &server,
   broadcast::Broadcast::broadcastPlayerShoot(
       server.getSocket(), server.getClients(), playerShotPacket);
 
-  return SUCCESS;
+  return OK;
 }
 
 int packet::PlayerDisconnectedHandler::handlePacket(server::Server &server,
@@ -176,11 +176,11 @@ int packet::PlayerDisconnectedHandler::handlePacket(server::Server &server,
                                                     const char *data,
                                                     std::size_t size) {
   if (size < sizeof(PlayerDisconnectPacket)) {
-    return ERROR;
+    return KO;
   }
   const auto *disc = reinterpret_cast<const PlayerDisconnectPacket *>(data);
   if (disc->player_id != static_cast<uint32_t>(client._player_id)) {
-    return ERROR;
+    return KO;
   }
   std::cout << "[WORLD] Player " << client._player_id << " disconnected."
             << std::endl;
@@ -207,5 +207,5 @@ int packet::PlayerDisconnectedHandler::handlePacket(server::Server &server,
       PacketBuilder::makePlayerDisconnect(client._player_id);
   broadcast::Broadcast::broadcastPlayerDisconnect(
       server.getSocket(), server.getClients(), disconnectPacket);
-  return SUCCESS;
+  return OK;
 }

--- a/server/src/player/Player.cpp
+++ b/server/src/player/Player.cpp
@@ -40,14 +40,14 @@ int game::Player::getHealth() const {
   if (hasComponent<ecs::HealthComponent>()) {
     return getComponent<ecs::HealthComponent>().health;
   }
-  return SUCCESS;
+  return OK;
 }
 
 int game::Player::getMaxHealth() const {
   if (hasComponent<ecs::HealthComponent>()) {
     return getComponent<ecs::HealthComponent>().max_health;
   }
-  return SUCCESS;
+  return OK;
 }
 
 void game::Player::setHealth(int health) {
@@ -111,7 +111,7 @@ uint32_t game::Player::getSequenceNumber() const {
   if (hasComponent<ecs::PlayerComponent>()) {
     return getComponent<ecs::PlayerComponent>().sequence_number;
   }
-  return SUCCESS;
+  return OK;
 }
 
 void game::Player::setSequenceNumber(uint32_t seq) {


### PR DESCRIPTION
Replaces the macros SUCCESS and ERROR with OK and KO throughout the server codebase for improved clarity and to avoid potential naming conflicts. Updates all relevant return statements and checks to use the new macro names.